### PR TITLE
Removed redundant light.On calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,6 @@ func main() {
 
 	lights, _ := bridge.GetAllLights()
 	for _, light := range lights {
-		light.On()
 		light.SetBrightness(100)
 	}
 


### PR DESCRIPTION
Light.On is called before Light.SetBrightness(100) which is not necessary because the [Light.SetBrightness Spec](https://github.com/Collinux/gohue/blob/master/light.go#L219) already sets the value of Light.On to true in the LightState struct.